### PR TITLE
Update EMSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Zig build package and shims for [Emscripten](https://emscripten.org) emsdk
 
 Add `zemscripten` and (optionally) `emsdk` to your build.zig.zon dependencies
 ```sh
-    zig fetch --save https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.73.tar.gz
+    zig fetch --save https://github.com/emscripten-core/emsdk/archive/refs/tags/4.0.3.tar.gz
 ```
 
 Emsdk must be activated before it can be used. You can use `activateEmsdkStep` to create a build step for that:

--- a/build.zig
+++ b/build.zig
@@ -1,9 +1,9 @@
 const builtin = @import("builtin");
 const std = @import("std");
 
-pub const emsdk_ver_major = "3";
-pub const emsdk_ver_minor = "1";
-pub const emsdk_ver_tiny = "73";
+pub const emsdk_ver_major = "4";
+pub const emsdk_ver_minor = "0";
+pub const emsdk_ver_tiny = "3";
 pub const emsdk_version = emsdk_ver_major ++ "." ++ emsdk_ver_minor ++ "." ++ emsdk_ver_tiny;
 
 pub fn build(b: *std.Build) void {


### PR DESCRIPTION
A bug was found in the ClearBuffer emscripten function. Needed an update. 

There should be another PR in zig-gamedev to finish the update.