### PR TITLE
Export synchronous wget functions

### DIFF
--- a/src/zemscripten.zig
+++ b/src/zemscripten.zig
@@ -202,7 +202,7 @@ pub fn log(
 extern fn emscripten_wget(url: [*c]const u8, file: [*c]const u8) c_int;
 extern fn emscripten_wget_data(url: [*c]const u8, pbuffer: **anyopaque, pnum: *c_int, perror: *c_int) void;
 
-pub fn Wget(url: []const u8, file: []const u8) c_int {
+pub fn Wget(url: [:0]const u8, file: [:0]const u8) c_int {
     return emscripten_wget(url.ptr, file.ptr);
 }
 

--- a/src/zemscripten.zig
+++ b/src/zemscripten.zig
@@ -197,3 +197,25 @@ pub fn log(
         else => emscripten_console_log(@ptrCast(msg.ptr)),
     }
 }
+
+// Networking
+extern fn emscripten_wget(url: [*c]const u8, file: [*c]const u8) c_int;
+extern fn emscripten_wget_data(url: [*c]const u8, pbuffer: **anyopaque, pnum: *c_int, perror: *c_int) void;
+
+pub fn Wget(url: []const u8, file: []const u8) c_int {
+    return emscripten_wget(url.ptr, file.ptr);
+}
+
+pub fn WgetData(url: []const u8) ![]u8 {
+    var buffer_ptr: *anyopaque = undefined;
+    var len: c_int = undefined;
+    var err: c_int = undefined;
+
+    emscripten_wget_data(url.ptr, &buffer_ptr, &len, &err);
+
+    if (err != 0) {
+        return error.WgetError;
+    }
+
+    return @as([*]u8, @ptrCast(buffer_ptr))[0..@intCast(len)];
+}

--- a/src/zemscripten.zig
+++ b/src/zemscripten.zig
@@ -202,11 +202,11 @@ pub fn log(
 extern fn emscripten_wget(url: [*c]const u8, file: [*c]const u8) c_int;
 extern fn emscripten_wget_data(url: [*c]const u8, pbuffer: **anyopaque, pnum: *c_int, perror: *c_int) void;
 
-pub fn Wget(url: [:0]const u8, file: [:0]const u8) c_int {
+pub fn wget(url: [:0]const u8, file: [:0]const u8) c_int {
     return emscripten_wget(url.ptr, file.ptr);
 }
 
-pub fn WgetData(url: [:0]const u8) ![]u8 {
+pub fn wget_data(url: [:0]const u8) ![]u8 {
     var buffer_ptr: *anyopaque = undefined;
     var len: c_int = undefined;
     var err: c_int = undefined;

--- a/src/zemscripten.zig
+++ b/src/zemscripten.zig
@@ -206,7 +206,7 @@ pub fn Wget(url: []const u8, file: []const u8) c_int {
     return emscripten_wget(url.ptr, file.ptr);
 }
 
-pub fn WgetData(url: []const u8) ![]u8 {
+pub fn WgetData(url: [:0]const u8) ![]u8 {
     var buffer_ptr: *anyopaque = undefined;
     var len: c_int = undefined;
     var err: c_int = undefined;


### PR DESCRIPTION
This PR adds `wget` and `wget_data` which are wrappers to Emscripten's `emscripten_wget` and `emscripten_wget_data`. To use them, `ASYNCIFY` should be enabled.